### PR TITLE
Fix for TX chunks smaller than channel buffer size

### DIFF
--- a/PlutoSDR_Streaming.cpp
+++ b/PlutoSDR_Streaming.cpp
@@ -89,6 +89,9 @@ int SoapyPlutoSDR::activateStream(
 	std::lock_guard<std::mutex> lock(device_mutex);
 	PlutoSDRStream *stream = reinterpret_cast<PlutoSDRStream *>(handle);
 
+	if (flags & ~SOAPY_SDR_END_BURST)
+		return SOAPY_SDR_NOT_SUPPORTED;
+
 	if (not stream->rx)
 		return 0;
 
@@ -484,7 +487,7 @@ int tx_streamer::send(	const void * const *buffs,
 
 	items_in_buf += items;
 
-	if (items_in_buf == buf_size) {
+	if (items_in_buf == buf_size || (flags & SOAPY_SDR_END_BURST && numElems == items)) {
 		int ret = send_buf();
 
 		if (ret < 0) {

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -57,16 +57,18 @@ class tx_streamer {
 		tx_streamer(const iio_device *dev, const std::string &format, const std::vector<size_t> &channels, const SoapySDR::Kwargs &args);
 		~tx_streamer();
 		int send(const void * const *buffs,const size_t numElems,int &flags,const long long timeNs,const long timeoutUs );
+		int flush();
 
 	private:
+		int send_buf();
 
-		void channel_write(iio_channel *chn,const void *src, size_t len);
 		std::vector<iio_channel* > channel_list;
 		const iio_device  *dev;
-		std::vector<int16_t> buffer;
 		std::string format;
 		std::mutex mutex;
 		iio_buffer  *buf;
+		size_t buf_size;
+		size_t items_in_buf;
 };
 
 


### PR DESCRIPTION
The iio channel always transfers a full buffer (4k), but SoapyRemote with a default MTU of 1500 will only supply 357 elements per call to `writeStream()`.
This change incrementally fills the TX channels and writes the buffer to hardware (push in iio lingo) only when it's full. The channels are also flushed on `closeStream()` and `deactivateStream()`.
Also removes the intermediate type conversion buffer (`buffer`) which isn't needed as we use `iio_channel_convert_inverse()` to copy element-wise anyway.

Fixes the root cause for pothosware/SoapyRemote#56.