### PR TITLE
Remove RX intermediate type conversion buffer

### DIFF
--- a/PlutoSDR_Streaming.cpp
+++ b/PlutoSDR_Streaming.cpp
@@ -209,8 +209,6 @@ rx_streamer::rx_streamer(const iio_device *_dev, const std::string &_format, con
 		this->set_buffer_size_by_samplerate(samplerate);
 	
 	}
-	buffer.reserve(buffer_size);
-	buffer.resize(buffer_size);
 
 	format = _format;
 
@@ -262,27 +260,37 @@ size_t rx_streamer::recv(void * const *buffs,
 
 	size_t items = std::min(items_in_buffer,numElems);
 
-	buffer.resize(items);
+	int16_t dst = 0;
+	uintptr_t src_ptr, dst_ptr = (uintptr_t)&dst;
+	ptrdiff_t buf_step = iio_buffer_step(buf);
+
 	for (unsigned int i = 0; i < channel_list.size(); i++) {
+		iio_channel *chn = channel_list[i];
 		unsigned int index = i / 2;
 
-		channel_read(channel_list[i], buffer.data(), items * sizeof(int16_t));
+		src_ptr = (uintptr_t)iio_buffer_first(buf, chn) + byte_offset;
 
 		if (format == SOAPY_SDR_CS16) {
 			int16_t *samples_cs16 = (int16_t *)buffs[index];
 			for (size_t j = 0; j < items; ++j) {
-				samples_cs16[j*2 + i]=buffer[j];
+				iio_channel_convert(chn, (void *)dst_ptr, (const void *)src_ptr);
+				src_ptr += buf_step;
+				samples_cs16[j * 2 + i] = dst;
 			}		
 		}else if (format == SOAPY_SDR_CF32) {
 			float *samples_cf32 = (float *)buffs[index];
 			for (size_t j = 0; j < items; ++j) {
-				samples_cf32[j * 2 + i] = lut[buffer[j] & 0x0FFF];
+				iio_channel_convert(chn, (void *)dst_ptr, (const void *)src_ptr);
+				src_ptr += buf_step;
+				samples_cf32[j * 2 + i] = lut[dst & 0x0FFF];
 			}
 		}
 		else if (format == SOAPY_SDR_CS8) {
 			int8_t *samples_cs8 = (int8_t *)buffs[index];
 			for (size_t j = 0; j < items; ++j) {
-				samples_cs8[j * 2 + i] = buffer[j] >> 4;
+				iio_channel_convert(chn, (void *)dst_ptr, (const void *)src_ptr);
+				src_ptr += buf_step;
+				samples_cs8[j * 2 + i] = dst >> 4;
 			}
 		}
 
@@ -386,21 +394,6 @@ void rx_streamer::refill_thread(){
 	}
 	thread_stopped = true;
 	cond2.notify_all();
-}
-
-
-void rx_streamer::channel_read(const struct iio_channel *chn, void *dst, size_t len) {
-
-	uintptr_t src_ptr, dst_ptr = (uintptr_t)dst, end = dst_ptr + len;
-	unsigned int length = iio_channel_get_data_format(chn)->length / 8;
-	uintptr_t buf_end = (uintptr_t)iio_buffer_end(buf);
-	ptrdiff_t buf_step = iio_buffer_step(buf);
-
-	for (src_ptr = (uintptr_t)iio_buffer_first(buf, chn)+ byte_offset;
-			src_ptr < buf_end && dst_ptr + length <= end;
-			src_ptr += buf_step, dst_ptr += length)
-		iio_channel_convert(chn,
-				(void *)dst_ptr, (const void *)src_ptr);
 }
 
 

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -41,7 +41,6 @@ class rx_streamer {
 		volatile bool thread_stopped, please_refill_buffer;
 		const iio_device  *dev;
 
-		std::vector<int16_t> buffer;
 		size_t buffer_size;
 		size_t byte_offset;
 		size_t items_in_buffer;


### PR DESCRIPTION
the current code copies the RX data to an intermediate buffer just to copy that buffer to the output user buffer again.
This change removes the intermediate copy step and folds the two tight copy loops for `iio_channel_convert()` and sample format conversion into one.