### PR TITLE
Streaming improvements

### DIFF
--- a/PlutoSDR_Settings.cpp
+++ b/PlutoSDR_Settings.cpp
@@ -158,7 +158,7 @@ std::vector<std::string> SoapyPlutoSDR::listAntennas( const int direction, const
 
 void SoapyPlutoSDR::setAntenna( const int direction, const size_t channel, const std::string &name )
 {
-	std::lock_guard<std::mutex> lock(device_mutex);
+    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
 
 	if (direction == SOAPY_SDR_RX) {
 
@@ -216,7 +216,8 @@ bool SoapyPlutoSDR::hasGainMode(const int direction, const size_t channel) const
 
 void SoapyPlutoSDR::setGainMode( const int direction, const size_t channel, const bool automatic )
 {
-	std::lock_guard<std::mutex> lock(device_mutex);
+    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
+
 	gainMode = automatic;
 	if(direction==SOAPY_SDR_RX){
 
@@ -239,7 +240,8 @@ bool SoapyPlutoSDR::getGainMode(const int direction, const size_t channel) const
 
 void SoapyPlutoSDR::setGain( const int direction, const size_t channel, const double value )
 {
-	std::lock_guard<std::mutex> lock(device_mutex);
+    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
+
 	long long gain = (long long) value;
 	if(direction==SOAPY_SDR_RX){
 
@@ -265,7 +267,7 @@ void SoapyPlutoSDR::setGain( const int direction, const size_t channel, const st
 
 double SoapyPlutoSDR::getGain( const int direction, const size_t channel, const std::string &name ) const
 {
-	std::lock_guard<std::mutex> lock(device_mutex);
+    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
 
 	long long gain = 0;
 
@@ -300,7 +302,8 @@ SoapySDR::Range SoapyPlutoSDR::getGainRange( const int direction, const size_t c
 
 void SoapyPlutoSDR::setFrequency( const int direction, const size_t channel, const std::string &name, const double frequency, const SoapySDR::Kwargs &args )
 {
-	std::lock_guard<std::mutex> lock(device_mutex);
+    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
+
 	long long freq = (long long)frequency;
 	if(direction==SOAPY_SDR_RX){
 
@@ -317,7 +320,8 @@ void SoapyPlutoSDR::setFrequency( const int direction, const size_t channel, con
 
 double SoapyPlutoSDR::getFrequency( const int direction, const size_t channel, const std::string &name ) const
 {
-	std::lock_guard<std::mutex> lock(device_mutex);
+    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
+
 	long long freq;
 
 	if(direction==SOAPY_SDR_RX){
@@ -364,7 +368,8 @@ SoapySDR::RangeList SoapyPlutoSDR::getFrequencyRange( const int direction, const
  ******************************************************************/
 void SoapyPlutoSDR::setSampleRate( const int direction, const size_t channel, const double rate )
 {
-	std::lock_guard<std::mutex> lock(device_mutex);
+    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
+
 	long long samplerate =(long long) rate;
 
 	if(direction==SOAPY_SDR_RX){
@@ -412,7 +417,8 @@ void SoapyPlutoSDR::setSampleRate( const int direction, const size_t channel, co
 
 double SoapyPlutoSDR::getSampleRate( const int direction, const size_t channel ) const
 {
-	std::lock_guard<std::mutex> lock(device_mutex);
+    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
+
 	long long samplerate;
 
 	if(direction==SOAPY_SDR_RX){
@@ -453,7 +459,8 @@ std::vector<double> SoapyPlutoSDR::listSampleRates( const int direction, const s
 
 void SoapyPlutoSDR::setBandwidth( const int direction, const size_t channel, const double bw )
 {
-	std::lock_guard<std::mutex> lock(device_mutex);
+    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
+
 	long long bandwidth = (long long) bw;
 	if(direction==SOAPY_SDR_RX){
 
@@ -470,7 +477,8 @@ void SoapyPlutoSDR::setBandwidth( const int direction, const size_t channel, con
 
 double SoapyPlutoSDR::getBandwidth( const int direction, const size_t channel ) const
 {
-	std::lock_guard<std::mutex> lock(device_mutex);
+    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
+
 	long long bandwidth;
 
 	if(direction==SOAPY_SDR_RX){

--- a/PlutoSDR_Settings.cpp
+++ b/PlutoSDR_Settings.cpp
@@ -158,15 +158,13 @@ std::vector<std::string> SoapyPlutoSDR::listAntennas( const int direction, const
 
 void SoapyPlutoSDR::setAntenna( const int direction, const size_t channel, const std::string &name )
 {
-    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
-
-	if (direction == SOAPY_SDR_RX) {
-
+   if (direction == SOAPY_SDR_RX) {
+       std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 		iio_channel_attr_write(iio_device_find_channel(dev, "voltage0", false), "rf_port_select", name.c_str());
 	}
 
-	if (direction == SOAPY_SDR_TX) {
-
+	else if (direction == SOAPY_SDR_TX) {
+        std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
 		iio_channel_attr_write(iio_device_find_channel(dev, "voltage0", true), "rf_port_select", name.c_str());
 
 	} 
@@ -180,7 +178,7 @@ std::string SoapyPlutoSDR::getAntenna( const int direction, const size_t channel
 	if (direction == SOAPY_SDR_RX) {
 		options = "A_BALANCED";
 	}
-	if (direction == SOAPY_SDR_TX) {
+	else if (direction == SOAPY_SDR_TX) {
 
 		options = "A";
 	}
@@ -216,11 +214,10 @@ bool SoapyPlutoSDR::hasGainMode(const int direction, const size_t channel) const
 
 void SoapyPlutoSDR::setGainMode( const int direction, const size_t channel, const bool automatic )
 {
-    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
 
 	gainMode = automatic;
 	if(direction==SOAPY_SDR_RX){
-
+        std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 		if (gainMode) {
 
 			iio_channel_attr_write(iio_device_find_channel(dev, "voltage0", false), "gain_control_mode", "slow_attack");
@@ -240,17 +237,15 @@ bool SoapyPlutoSDR::getGainMode(const int direction, const size_t channel) const
 
 void SoapyPlutoSDR::setGain( const int direction, const size_t channel, const double value )
 {
-    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
-
 	long long gain = (long long) value;
 	if(direction==SOAPY_SDR_RX){
-
+        std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "voltage0", false),"hardwaregain", gain);
 
 	}
 
-	if(direction==SOAPY_SDR_TX){
-
+	else if(direction==SOAPY_SDR_TX){
+        std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
 		gain = gain - 89;
 		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "voltage0", true),"hardwaregain", gain);
 
@@ -260,26 +255,25 @@ void SoapyPlutoSDR::setGain( const int direction, const size_t channel, const do
 
 void SoapyPlutoSDR::setGain( const int direction, const size_t channel, const std::string &name, const double value )
 {
-
 	this->setGain(direction,channel,value);
-
 }
 
 double SoapyPlutoSDR::getGain( const int direction, const size_t channel, const std::string &name ) const
 {
-    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
-
 	long long gain = 0;
 
 	if(direction==SOAPY_SDR_RX){
+
+        std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 
 		if(iio_channel_attr_read_longlong(iio_device_find_channel(dev, "voltage0", false),"hardwaregain",&gain )!=0)
 			return 0;
 
 	}
 
-	if(direction==SOAPY_SDR_TX){
+	else if(direction==SOAPY_SDR_TX){
 
+        std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
 
 		if(iio_channel_attr_read_longlong(iio_device_find_channel(dev, "voltage0", true),"hardwaregain",&gain )!=0)
 			return 0;
@@ -302,16 +296,15 @@ SoapySDR::Range SoapyPlutoSDR::getGainRange( const int direction, const size_t c
 
 void SoapyPlutoSDR::setFrequency( const int direction, const size_t channel, const std::string &name, const double frequency, const SoapySDR::Kwargs &args )
 {
-    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
-
 	long long freq = (long long)frequency;
 	if(direction==SOAPY_SDR_RX){
 
+        std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "altvoltage0", true),"frequency", freq);
 	}
 
-	if(direction==SOAPY_SDR_TX){
-
+	else if(direction==SOAPY_SDR_TX){
+        std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
 		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "altvoltage1", true),"frequency", freq);
 
 	}
@@ -320,18 +313,20 @@ void SoapyPlutoSDR::setFrequency( const int direction, const size_t channel, con
 
 double SoapyPlutoSDR::getFrequency( const int direction, const size_t channel, const std::string &name ) const
 {
-    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
-
-	long long freq;
+  	long long freq;
 
 	if(direction==SOAPY_SDR_RX){
+
+        std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 
 		if(iio_channel_attr_read_longlong(iio_device_find_channel(dev, "altvoltage0", true),"frequency",&freq )!=0)
 			return 0;
 
 	}
 
-	if(direction==SOAPY_SDR_TX){
+	else if(direction==SOAPY_SDR_TX){
+
+        std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
 
 		if(iio_channel_attr_read_longlong(iio_device_find_channel(dev, "altvoltage1", true),"frequency",&freq )!=0)
 			return 0;
@@ -368,11 +363,10 @@ SoapySDR::RangeList SoapyPlutoSDR::getFrequencyRange( const int direction, const
  ******************************************************************/
 void SoapyPlutoSDR::setSampleRate( const int direction, const size_t channel, const double rate )
 {
-    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
-
 	long long samplerate =(long long) rate;
 
 	if(direction==SOAPY_SDR_RX){
+        std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 		decimation = false;
 		if (samplerate<(25e6 / 48)) {
 			if (samplerate * 8 < (25e6 / 48)) {
@@ -391,7 +385,8 @@ void SoapyPlutoSDR::setSampleRate( const int direction, const size_t channel, co
 			rx_stream->set_buffer_size_by_samplerate(decimation ? samplerate / 8 : samplerate);
 	}
 
-	if(direction==SOAPY_SDR_TX){
+	else if(direction==SOAPY_SDR_TX){
+        std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
 		interpolation = false;
 		if (samplerate<(25e6 / 48)) {
 			if (samplerate * 8 < (25e6 / 48)) {
@@ -409,7 +404,7 @@ void SoapyPlutoSDR::setSampleRate( const int direction, const size_t channel, co
 	}
 
 #ifdef HAS_AD9361_IIO
-	if(ad9361_set_bb_rate(dev,samplerate))
+	if(ad9361_set_bb_rate(dev,(unsigned long)samplerate))
 		SoapySDR_logf(SOAPY_SDR_ERROR, "Unable to set BB rate.");	
 #endif
 
@@ -417,17 +412,19 @@ void SoapyPlutoSDR::setSampleRate( const int direction, const size_t channel, co
 
 double SoapyPlutoSDR::getSampleRate( const int direction, const size_t channel ) const
 {
-    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
-
 	long long samplerate;
 
 	if(direction==SOAPY_SDR_RX){
+
+        std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 
 		if(iio_channel_attr_read_longlong(iio_device_find_channel(rx_dev, "voltage0", false),"sampling_frequency",&samplerate )!=0)
 			return 0;
 	}
 
-	if(direction==SOAPY_SDR_TX){
+	else if(direction==SOAPY_SDR_TX){
+        
+        std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
 
 		if(iio_channel_attr_read_longlong(iio_device_find_channel(tx_dev, "voltage0", true),"sampling_frequency",&samplerate)!=0)
 			return 0;
@@ -459,36 +456,33 @@ std::vector<double> SoapyPlutoSDR::listSampleRates( const int direction, const s
 
 void SoapyPlutoSDR::setBandwidth( const int direction, const size_t channel, const double bw )
 {
-    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
-
 	long long bandwidth = (long long) bw;
 	if(direction==SOAPY_SDR_RX){
-
+        std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "voltage0", false),"rf_bandwidth", bandwidth);
 	}
 
-	if(direction==SOAPY_SDR_TX){
-
+	else if(direction==SOAPY_SDR_TX){
+        std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
 		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "voltage0", true),"rf_bandwidth", bandwidth);
-
 	}
 
 }
 
 double SoapyPlutoSDR::getBandwidth( const int direction, const size_t channel ) const
 {
-    std::lock_guard<pluto_spin_mutex> lock(device_mutex);
-
-	long long bandwidth;
+    long long bandwidth;
 
 	if(direction==SOAPY_SDR_RX){
+        std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 
 		if(iio_channel_attr_read_longlong(iio_device_find_channel(dev, "voltage0", false),"rf_bandwidth",&bandwidth )!=0)
 			return 0;
 
 	}
 
-	if(direction==SOAPY_SDR_TX){
+	else if(direction==SOAPY_SDR_TX){
+        std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
 
 		if(iio_channel_attr_read_longlong(iio_device_find_channel(dev, "voltage0", true),"rf_bandwidth",&bandwidth )!=0)
 			return 0;

--- a/PlutoSDR_Settings.cpp
+++ b/PlutoSDR_Settings.cpp
@@ -4,6 +4,7 @@
 #endif
 
 static iio_context *ctx = nullptr; 
+
 SoapyPlutoSDR::SoapyPlutoSDR( const SoapySDR::Kwargs &args ):
 	dev(nullptr), rx_dev(nullptr),tx_dev(nullptr), decimation(false), interpolation(false), rx_stream(nullptr)
 {
@@ -158,6 +159,7 @@ std::vector<std::string> SoapyPlutoSDR::listAntennas( const int direction, const
 void SoapyPlutoSDR::setAntenna( const int direction, const size_t channel, const std::string &name )
 {
 	std::lock_guard<std::mutex> lock(device_mutex);
+
 	if (direction == SOAPY_SDR_RX) {
 
 		iio_channel_attr_write(iio_device_find_channel(dev, "voltage0", false), "rf_port_select", name.c_str());
@@ -264,6 +266,7 @@ void SoapyPlutoSDR::setGain( const int direction, const size_t channel, const st
 double SoapyPlutoSDR::getGain( const int direction, const size_t channel, const std::string &name ) const
 {
 	std::lock_guard<std::mutex> lock(device_mutex);
+
 	long long gain = 0;
 
 	if(direction==SOAPY_SDR_RX){

--- a/PlutoSDR_Streaming.cpp
+++ b/PlutoSDR_Streaming.cpp
@@ -111,7 +111,7 @@ SoapySDR::Stream *SoapyPlutoSDR::setupStream(
 
         std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
 
-        this->rx_stream = std::make_unique<rx_streamer>(rx_dev, streamFormat, channels, args);
+        this->rx_stream = std::unique_ptr<rx_streamer>(new rx_streamer (rx_dev, streamFormat, channels, args));
 
         return reinterpret_cast<SoapySDR::Stream*>(this->rx_stream.get());
 	}
@@ -120,7 +120,7 @@ SoapySDR::Stream *SoapyPlutoSDR::setupStream(
 
         std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
 
-        this->tx_stream = std::make_unique<tx_streamer>(tx_dev, streamFormat, channels, args);
+        this->tx_stream = std::unique_ptr<tx_streamer>(new tx_streamer (tx_dev, streamFormat, channels, args));
 
         return reinterpret_cast<SoapySDR::Stream*>(this->tx_stream.get());
 	}

--- a/PlutoSDR_Streaming.cpp
+++ b/PlutoSDR_Streaming.cpp
@@ -79,23 +79,6 @@ bool SoapyPlutoSDR::IsValidTxStreamHandle(SoapySDR::Stream* handle)
     return false;
 }
 
-bool SoapyPlutoSDR::IsValidStreamHandle(SoapySDR::Stream* handle, const int direction)
-{
-    if (handle == nullptr) {
-        return false;
-    }
-
-    //handle is an opaque pointer hiding either rx_stream or tx_streamer:
-    //check that the handle matches one of them, onsistently with direction:
-    if (direction == SOAPY_SDR_RX && IsValidRxStreamHandle(handle)) {
-        return true;
-    } else if (direction == SOAPY_SDR_TX && IsValidTxStreamHandle(handle)) {
-
-        return true;
-    }
-    return false;
-}
-
 SoapySDR::Stream *SoapyPlutoSDR::setupStream(
 		const int direction,
 		const std::string &format,

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -266,7 +266,6 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 
         bool IsValidRxStreamHandle(SoapySDR::Stream* handle);
         bool IsValidTxStreamHandle(SoapySDR::Stream* handle);
-        bool IsValidStreamHandle(SoapySDR::Stream* handle, const int direction);
        
 		iio_device *dev;
 		iio_device *rx_dev;

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -272,7 +272,7 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 		mutable std::mutex device_mutex;
 
 		bool decimation, interpolation;
-		std::shared_ptr<rx_streamer> rx_stream;
-        std::shared_ptr<tx_streamer> tx_stream;
+		std::unique_ptr<rx_streamer> rx_stream;
+        std::unique_ptr<tx_streamer> tx_stream;
 };
 

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -81,6 +81,10 @@ class pluto_spin_mutex {
 public:
     pluto_spin_mutex() = default;
 
+    pluto_spin_mutex(const pluto_spin_mutex&) = delete;
+
+    pluto_spin_mutex& operator=(const pluto_spin_mutex&) = delete;
+
     ~pluto_spin_mutex() { lock_state.clear(std::memory_order_release); }
 
     void lock() { while (lock_state.test_and_set(std::memory_order_acquire)); }
@@ -289,7 +293,8 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 		iio_device *tx_dev;
 		bool gainMode;
 
-		mutable pluto_spin_mutex device_mutex;
+		mutable pluto_spin_mutex rx_device_mutex;
+        mutable pluto_spin_mutex tx_device_mutex;
 
 		bool decimation, interpolation;
 		std::unique_ptr<rx_streamer> rx_stream;

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -3,7 +3,7 @@
 #include <mutex>
 #include <thread>
 #include <chrono>
-#include <condition_variable>
+#include <atomic>
 #include <SoapySDR/Device.hpp>
 #include <SoapySDR/Logger.hpp>
 #include <SoapySDR/Formats.hpp>
@@ -37,17 +37,9 @@ class rx_streamer {
 
 		void set_buffer_size(const size_t _buffer_size);
 
-		void channel_read(const struct iio_channel *chn, void *dst, size_t len);
-
-		void refill_thread();
-
 		bool has_direct_copy();
 
-		std::thread refill_thd;
-		std::mutex mutex;
-		std::condition_variable cond, cond2;
 		std::vector<iio_channel* > channel_list;
-		volatile bool thread_stopped, please_refill_buffer;
 		const iio_device  *dev;
 
 		size_t buffer_size;
@@ -276,8 +268,11 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 		iio_device *rx_dev;
 		iio_device *tx_dev;
 		bool gainMode;
+
 		mutable std::mutex device_mutex;
+
 		bool decimation, interpolation;
 		std::shared_ptr<rx_streamer> rx_stream;
+        std::shared_ptr<tx_streamer> tx_stream;
 };
 

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -264,6 +264,10 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 
 	private:
 
+        bool IsValidRxStreamHandle(SoapySDR::Stream* handle);
+        bool IsValidTxStreamHandle(SoapySDR::Stream* handle);
+        bool IsValidStreamHandle(SoapySDR::Stream* handle, const int direction);
+       
 		iio_device *dev;
 		iio_device *rx_dev;
 		iio_device *tx_dev;


### PR DESCRIPTION
Hello Charles, @zuckschwerdt and @guruofquality.

Thanks to suggestions and tests by @zuckschwerdt, I've incremented them by opening this PR to add improvements of my own together with the others. 
@guruofquality  I don't know if @zuckschwerdt can push on this PR ? 

Anyway, here are the improvements  :
- Completed the removal  of the fill thread initiated by @zuckschwerdt : there is no need of buffer mutex at all finally, atomic counters on buffer sizes are enough. This is even simpler than SoapySDRPlay, since `iio_buffers` has their own buffer management.
- Enabled "direct copy" for CS8 and CF32 (the format used by CubicSDR) because thanks to having the same endianness, you only have to scale and cast manually the `int16_t` into the  destination format and don't need `iio_channel_convert` at all.
- Removed LUT for CF32 for simplification. Given the SoapySDRPlay and others don't have it, I guess the eventual perfomance gain is not worth the additional code.

Of course, this is a work in progress:
- I've not touched the TX part,
- It may be entirely wrong,
- I have not found the sweet spot for MTU vs. set_buffer_size vs. samplerate, and so far only managed 5Msps on CubicSDR without cracking sound. 
- Maybe the refill_thread would be needed after all to pre-buffer the samples, if the `refill_buffer` op turns out to be too slow. I hope not.