### PR TITLE
Add direct copy for all formats, remove LUT

### DIFF
--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -54,7 +54,6 @@ class rx_streamer {
 		size_t items_in_buffer;
 		iio_buffer  *buf;
 		const plutosdrStreamFormat format;
-		float lut[4096];
 		bool direct_copy;
 
 };


### PR DESCRIPTION
Adds the fast copy loops for CF32 and CS8 from #14.

Also updates the code style with narrower var scope, easier to follow names (data flow is src > conv > dst), replaces uintptr_t with uint8_t for well defined pointer arithmetic, and drops explicit void casts.