### PR TITLE
Add CS12 support

### DIFF
--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -11,6 +11,7 @@
 typedef enum plutosdrStreamFormat {
 	PLUTO_SDR_CF32,
 	PLUTO_SDR_CS16,
+	PLUTO_SDR_CS12,
 	PLUTO_SDR_CS8
 } plutosdrStreamFormat;
 


### PR DESCRIPTION
Adds support for CS12. Only available with direct copy.
Intended for 8 Msps (and lower) over SoapyRemote. Use CS8 with SoapyRemote for 10 Msps.