### PR TITLE
MTU adaptaion w.r.t sample rate

### DIFF
--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -33,9 +33,16 @@ class rx_streamer {
 
 		void set_buffer_size_by_samplerate(const size_t _samplerate);
 
+       
+        size_t get_buffer_size();
+
+        size_t get_mtu_size();
+
 	private:
 
 		void set_buffer_size(const size_t _buffer_size);
+
+        void set_mtu_size(const size_t mtu_size);
 
 		bool has_direct_copy();
 
@@ -48,6 +55,7 @@ class rx_streamer {
 		iio_buffer  *buf;
 		const plutosdrStreamFormat format;
 		bool direct_copy;
+        size_t mtu_size;
 
 };
 
@@ -285,7 +293,7 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 
 	private:
 
-        bool IsValidRxStreamHandle(SoapySDR::Stream* handle);
+        bool IsValidRxStreamHandle(SoapySDR::Stream* handle) const;
         bool IsValidTxStreamHandle(SoapySDR::Stream* handle);
        
 		iio_device *dev;


### PR DESCRIPTION
The dynamically adapts the `getStreamMTU` w.r.t current sample rate. 
This is used by CubicSDR to determine how much samples are fetched at a time. 
The current value = 64K was too big for < 6MHz sample rates, so roughly make MTU smaller when sample rate is smaller as well, to prevent cracking sound.

Also restored buffer size= 64K * 2 which seems to be an ideal size. 