### PR TITLE
Ensure that discovered libiio context is a PlutoSDR

### DIFF
--- a/PlutoSDR_Registration.cpp
+++ b/PlutoSDR_Registration.cpp
@@ -47,10 +47,18 @@ static std::vector<SoapySDR::Kwargs> find_PlutoSDR(const SoapySDR::Kwargs &args)
 			if (ctx != nullptr) {
 				options["uri"] = std::string(iio_context_info_get_uri(info[i]));
 
-				// if uri is specified in kwargs, discovered uri must match
-				if (args.count("uri") == 0 || options["uri"] == args.at("uri")) {
-					sprintf(label_str, "%s #%d %s", options["device"].c_str(), i, options["uri"].c_str());
-					results.push_back(options);
+				// check if discovered libiio context can be a PlutoSDR (and not some other sensor),
+				// it must contain "ad9361-phy", "cf-ad9361-lpc" and "cf-ad9361-dds-core-lpc" devices
+				iio_device *dev = iio_context_find_device(ctx, "ad9361-phy");
+				iio_device *rx_dev = iio_context_find_device(ctx, "cf-ad9361-lpc");
+				iio_device *tx_dev = iio_context_find_device(ctx, "cf-ad9361-dds-core-lpc");
+
+				if (dev != nullptr && rx_dev != nullptr && tx_dev != nullptr) {
+					// if uri is specified in kwargs, discovered uri must match
+					if (args.count("uri") == 0 || options["uri"] == args.at("uri")) {
+						sprintf(label_str, "%s #%d %s", options["device"].c_str(), i, options["uri"].c_str());
+						results.push_back(options);
+					}
 				}
 
 				if (ctx != nullptr)iio_context_destroy(ctx);

--- a/PlutoSDR_Registration.cpp
+++ b/PlutoSDR_Registration.cpp
@@ -46,8 +46,13 @@ static std::vector<SoapySDR::Kwargs> find_PlutoSDR(const SoapySDR::Kwargs &args)
 			ctx = iio_create_context_from_uri(iio_context_info_get_uri(info[i]));
 			if (ctx != nullptr) {
 				options["uri"] = std::string(iio_context_info_get_uri(info[i]));
-				sprintf(label_str, "%s #%d %s", options["device"].c_str(), i, options["uri"].c_str());
-				results.push_back(options);
+
+				// if uri is specified in kwargs, discovered uri must match
+				if (args.count("uri") == 0 || options["uri"] == args.at("uri")) {
+					sprintf(label_str, "%s #%d %s", options["device"].c_str(), i, options["uri"].c_str());
+					results.push_back(options);
+				}
+
 				if (ctx != nullptr)iio_context_destroy(ctx);
 			}
 


### PR DESCRIPTION
## Problem
Some new laptops contain sensors (e.g. accelerometers) that are handled by `libiio`. This causes SoapySDR to discover a PlutoSDR in the local `libiio` context, even though it is only some other internal sensor of the laptop.

Here, for example, there is *no PlutoSDR connected to the computer*:
```
[florian@thinkbook ~]$ SoapySDRUtil --find
######################################################
##     Soapy SDR -- the SDR abstraction library     ##
######################################################

Found device 0
  device = plutosdr
  driver = plutosdr
  uri = local:
```

What is worse, this makes `SoapyPlutoSDR` unusable on such devices. Even when specifying a `uri` in the arguments to `SoapySDR::Device::make`, *this parameter is simply ignored* and instead, SoapyPlutoSDR tries to open the first discovered local device, which is just some sensor:
```
######################################################
##     Soapy SDR -- the SDR abstraction library     ##
######################################################

Probe device uri=usb:3.7.5
[ERROR] no device found in this context.
Error probing device: no device found in this context
```
This issue was also previously reported in https://github.com/pothosware/SoapyPlutoSDR/issues/37 .

## Solution
This PR changes two things:
* If a `uri` is specified, take this information into account in `SoapySDR::Device::make`
* Ensure that a discovered device really is a PlutoSDR. This is done by checking if the `ad9361-phy`, `cf-ad9361-lpc` and `cf-ad9361-dds-core-lpc` libiio devices are present. Compared to alternative PlutoSDR detection methods (e.g. searching the libiio context description for the `ADALM-PLUTO` string), this has the advantage that non-official PlutoSDR clones should also just keep working.