### PR TITLE
Add getSampleRateRange() API

### DIFF
--- a/PlutoSDR_Settings.cpp
+++ b/PlutoSDR_Settings.cpp
@@ -643,6 +643,24 @@ std::vector<double> SoapyPlutoSDR::listSampleRates( const int direction, const s
 
 }
 
+SoapySDR::RangeList SoapyPlutoSDR::getSampleRateRange( const int direction, const size_t channel ) const
+{
+	SoapySDR::RangeList results;
+
+	// note that there are some gaps and rounding errors since we get truncated values form IIO
+	// e.g. 25e6/12 = 2083333.333 is read as 2083333 but written as 2083334
+#ifdef HAS_AD9361_IIO
+	// assume ad9361_set_bb_rate(), if available, will load x4 FIR as needed
+	// below 25e6/96 needs x8 decimation/interpolation and x4 FIR, minimum is 25e6/384
+	results.push_back(SoapySDR::Range(25e6 / 384, 61440000));
+#else
+	// sample rates below 25e6/12 need x8 decimation/interpolation (or x4 FIR to 25e6/48)
+	results.push_back(SoapySDR::Range(25e6 / 96, 61440000));
+#endif
+
+	return results;
+}
+
 void SoapyPlutoSDR::setBandwidth( const int direction, const size_t channel, const double bw )
 {
 	long long bandwidth = (long long) bw;

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <SoapySDR/Device.hpp>
 #include <SoapySDR/Logger.hpp>
+#include <SoapySDR/Types.hpp>
 #include <SoapySDR/Formats.hpp>
 
 typedef enum plutosdrStreamFormat {
@@ -296,7 +297,7 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 
 		std::vector<double> listBandwidths( const int direction, const size_t channel ) const;
 
-       
+		SoapySDR::RangeList getSampleRateRange(const int direction, const size_t channel) const;
 
 	private:
 


### PR DESCRIPTION
Enable arbitrary sample rates in applications that use [`getSampleRateRange()`](https://github.com/pothosware/SoapySDR/blob/master/include/SoapySDR/Device.hpp#L903-L909).

See also #43 