### PR TITLE
Disable automatic gain on startup

### DIFF
--- a/PlutoSDR_Settings.cpp
+++ b/PlutoSDR_Settings.cpp
@@ -42,6 +42,7 @@ SoapyPlutoSDR::SoapyPlutoSDR( const SoapySDR::Kwargs &args ):
 	}
 
 	this->setAntenna(SOAPY_SDR_RX, 0, "A_BALANCED");
+	this->setGainMode(SOAPY_SDR_RX, 0, false);
 	this->setAntenna(SOAPY_SDR_TX, 0, "A");
 }
 


### PR DESCRIPTION
Unlike some other devices, PlutoSDR starts up with automatic gain enabled. Despite this, `SoapyPlutoSDR::getGainMode` (incorrectly) returns `false` until the first time `SoapyPlutoSDR::setGainMode` is called. I think it would be best to match the behaviour of other devices and initialize the hardware with automatic gain disabled, so I've added a `setGainMode` call to the constructor. After this change, the automatic gain control setting in Gqrx works correctly with PlutoSDR.