### PR TITLE
Added option to specify frequency offset

### DIFF
--- a/PlutoSDR_Registration.cpp
+++ b/PlutoSDR_Registration.cpp
@@ -13,7 +13,6 @@ static std::vector<SoapySDR::Kwargs> find_PlutoSDR(const SoapySDR::Kwargs &args)
 	iio_scan_context *scan_ctx;
 	iio_context_info **info;
 	SoapySDR::Kwargs options;
-    
 	// Backends can error, scan each one individually
 	std::vector<std::string> backends = {"local", "usb", "ip"};
 	for (std::vector<std::string>::iterator it = backends.begin(); it != backends.end(); it++) {

--- a/PlutoSDR_Registration.cpp
+++ b/PlutoSDR_Registration.cpp
@@ -33,8 +33,8 @@ static std::vector<SoapySDR::Kwargs> find_PlutoSDR(const SoapySDR::Kwargs &args)
 		}
 
 		options["device"] = "PlutoSDR";
-        if (args.count("frequency_offset") != 0)
-            options["frequency_offset"] = args.at("frequency_offset");
+        if (args.count("freq_offset") != 0)
+            options["freq_offset"] = args.at("freq_offset");
             
 		if (ret == 0) {
 			iio_context_info_list_free(info);

--- a/PlutoSDR_Registration.cpp
+++ b/PlutoSDR_Registration.cpp
@@ -13,7 +13,7 @@ static std::vector<SoapySDR::Kwargs> find_PlutoSDR(const SoapySDR::Kwargs &args)
 	iio_scan_context *scan_ctx;
 	iio_context_info **info;
 	SoapySDR::Kwargs options;
-
+    
 	// Backends can error, scan each one individually
 	std::vector<std::string> backends = {"local", "usb", "ip"};
 	for (std::vector<std::string>::iterator it = backends.begin(); it != backends.end(); it++) {
@@ -34,6 +34,9 @@ static std::vector<SoapySDR::Kwargs> find_PlutoSDR(const SoapySDR::Kwargs &args)
 		}
 
 		options["device"] = "PlutoSDR";
+        if (args.count("frequency_offset") != 0)
+            options["frequency_offset"] = args.at("frequency_offset");
+            
 		if (ret == 0) {
 			iio_context_info_list_free(info);
 			iio_scan_context_destroy(scan_ctx);

--- a/PlutoSDR_Settings.cpp
+++ b/PlutoSDR_Settings.cpp
@@ -15,10 +15,10 @@ SoapyPlutoSDR::SoapyPlutoSDR( const SoapySDR::Kwargs &args ):
 	if (args.count("label") != 0)
 		SoapySDR_logf( SOAPY_SDR_INFO, "Opening %s...", args.at("label").c_str());
 
-	if (args.count("frequency_offset") != 0)
+	if (args.count("freq_offset") != 0)
     {
-		SoapySDR_logf( SOAPY_SDR_INFO, "Frequency offset %s Hz", args.at("frequency_offset").c_str());
-        frequencyOffset = std::stof(args.at("frequency_offset"));
+		SoapySDR_logf( SOAPY_SDR_INFO, "Frequency offset %s PPM", args.at("freq_offset").c_str());
+        frequencyOffset = std::stof(args.at("freq_offset"));
     }
 
 	if(ctx == nullptr)
@@ -483,12 +483,12 @@ void SoapyPlutoSDR::setFrequency( const int direction, const size_t channel, con
 	if(direction==SOAPY_SDR_RX){
 
         std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
-		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "altvoltage0", true),"frequency", freq - frequencyOffset);
+		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "altvoltage0", true),"frequency", freq * (1 - frequencyOffset*1e-6));
 	}
 
 	else if(direction==SOAPY_SDR_TX){
         std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
-		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "altvoltage1", true),"frequency", freq - frequencyOffset);
+		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "altvoltage1", true),"frequency", freq * (1 - frequencyOffset*1e-6));
 
 	}
 
@@ -516,7 +516,7 @@ double SoapyPlutoSDR::getFrequency( const int direction, const size_t channel, c
 
 	}
 
-	return double(freq);
+	return double(freq / (1 - frequencyOffset*1e-6));
 
 }
 

--- a/PlutoSDR_Settings.cpp
+++ b/PlutoSDR_Settings.cpp
@@ -10,9 +10,16 @@ SoapyPlutoSDR::SoapyPlutoSDR( const SoapySDR::Kwargs &args ):
 {
 
 	gainMode = false;
+    frequencyOffset = 0;
 
 	if (args.count("label") != 0)
 		SoapySDR_logf( SOAPY_SDR_INFO, "Opening %s...", args.at("label").c_str());
+
+	if (args.count("frequency_offset") != 0)
+    {
+		SoapySDR_logf( SOAPY_SDR_INFO, "Frequency offset %s Hz", args.at("frequency_offset").c_str());
+        frequencyOffset = std::stof(args.at("frequency_offset"));
+    }
 
 	if(ctx == nullptr)
 	{
@@ -476,12 +483,12 @@ void SoapyPlutoSDR::setFrequency( const int direction, const size_t channel, con
 	if(direction==SOAPY_SDR_RX){
 
         std::lock_guard<pluto_spin_mutex> lock(rx_device_mutex);
-		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "altvoltage0", true),"frequency", freq);
+		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "altvoltage0", true),"frequency", freq - frequencyOffset);
 	}
 
 	else if(direction==SOAPY_SDR_TX){
         std::lock_guard<pluto_spin_mutex> lock(tx_device_mutex);
-		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "altvoltage1", true),"frequency", freq);
+		iio_channel_attr_write_longlong(iio_device_find_channel(dev, "altvoltage1", true),"frequency", freq - frequencyOffset);
 
 	}
 

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -312,7 +312,7 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 		iio_device *dev;
 		iio_device *rx_dev;
 		iio_device *tx_dev;
-		bool gainMode;
+        bool gainMode;
         float frequencyOffset;
 
 		mutable pluto_spin_mutex rx_device_mutex;

--- a/SoapyPlutoSDR.hpp
+++ b/SoapyPlutoSDR.hpp
@@ -313,6 +313,7 @@ class SoapyPlutoSDR : public SoapySDR::Device{
 		iio_device *rx_dev;
 		iio_device *tx_dev;
 		bool gainMode;
+        float frequencyOffset;
 
 		mutable pluto_spin_mutex rx_device_mutex;
         mutable pluto_spin_mutex tx_device_mutex;


### PR DESCRIPTION
ADALM Pluto usually has quite a large frequency offset (mine has 20 kHz). Many applications cannot handle this offset (ie srsRAN). With this option srsRAN's cellscan works if I specify 20 kHz offset.